### PR TITLE
test separator with jupiter extension context

### DIFF
--- a/src/test/java/CalculatorTest.java
+++ b/src/test/java/CalculatorTest.java
@@ -1,11 +1,16 @@
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.example.Calculator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tests.AbstractTest;
 
-public class CalculatorTest {
+
+public class CalculatorTest extends AbstractTest {
 
     private Calculator calculator;
+    private static final Logger logger = LogManager.getLogger(CalculatorTest.class);
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/tests/AbstractTest.java
+++ b/src/test/java/tests/AbstractTest.java
@@ -1,0 +1,7 @@
+package tests;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(LoggingExtension.class)
+public abstract class AbstractTest {
+}

--- a/src/test/java/tests/LoggingExtension.java
+++ b/src/test/java/tests/LoggingExtension.java
@@ -1,0 +1,20 @@
+package tests;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Collections;
+
+public class LoggingExtension implements BeforeEachCallback {
+    private static final Logger LOGGER = LogManager.getLogger(LoggingExtension.class);
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        String test = context.getRequiredTestMethod().getName();
+        String testClass = context.getTestClass().get().getName();
+        LOGGER.info(String.join("", Collections.nCopies(80, "#")));
+        LOGGER.info("Starting: " + testClass + "." + test);
+    }
+}


### PR DESCRIPTION
example test separator for tests with more logs in format: 

```
Starting: CalculatorTest.testSubtract
################################################################################
```